### PR TITLE
Create config key jellybeans_loud_todo

### DIFF
--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -321,7 +321,12 @@ call s:X("Cursor","","b0d0f0","","","")
 
 call s:X("LineNr","605958",g:jellybeans_background_color,"none",s:termBlack,"")
 call s:X("Comment","888888","","italic","Grey","")
-call s:X("Todo","c7c7c7","","bold","White",s:termBlack)
+
+if !exists("g:jellybeans_loud_todo")
+  call s:X("Todo","c7c7c7","","bold","White",s:termBlack)
+else
+  call s:X("Todo","303030","F0F000","bold","White",s:termBlack)
+endif
 
 call s:X("StatusLine","000000","dddddd","italic","","White")
 call s:X("StatusLineNC","ffffff","403c41","italic","White","Black")


### PR DESCRIPTION
Just makes TODO's brighter, and means I can use mainline jellybeans
again

I'm open to changing this to `jellybeans_todo_fg` and `jellybeans_todo_bg` if you want.
