### PR TITLE
Fix can be disable ctermbg if background_color args is empty.

### DIFF
--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -507,10 +507,12 @@ if !s:low_color
   hi CursorColumn ctermbg=234
   hi CursorLine ctermbg=234
   hi SpecialKey ctermbg=234
-  exec "hi NonText ctermbg=".g:jellybeans_background_color_256
-  exec "hi LineNr ctermbg=".g:jellybeans_background_color_256
+  if g:jellybeans_background_color_256 !=# ''
+    exec "hi NonText ctermbg=".g:jellybeans_background_color_256
+    exec "hi LineNr ctermbg=".g:jellybeans_background_color_256
+    exec "hi Normal ctermbg=".g:jellybeans_background_color_256
+  endif
   hi DiffText ctermfg=81
-  exec "hi Normal ctermbg=".g:jellybeans_background_color_256
   hi DbgBreakPt ctermbg=53
   hi IndentGuidesOdd ctermbg=235
   hi IndentGuidesEven ctermbg=234


### PR DESCRIPTION
I tried to fix it because it was inconvenient and can not be disabled is ctermbg such as Normal and even though it has already been managed by the args much trouble.