### PR TITLE
Tweaked colors of of HTML and XML tags.

### DIFF
--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -434,6 +434,18 @@ call s:X("rubyRegexpSpecial","a40073","","","Magenta","")
 
 call s:X("rubyPredefinedIdentifier","de5577","","","Red","")
 
+" XML
+
+call s:X("xmlTag","8197bf","","","DarkBlue","")
+call s:X("xmlTagName","8197bf","","","DarkBlue","")
+call s:X("xmlEndTag","8197bf","","","DarkBlue","")
+
+" HTML
+
+call s:X("htmlTag","8197bf","","","DarkBlue","")
+call s:X("htmlTagName","8197bf","","","DarkBlue","")
+call s:X("htmlEndTag","8197bf","","","DarkBlue","")
+
 " Erlang
 
 hi! link erlangAtom rubySymbol


### PR DESCRIPTION
It always bugged me that the brackets were different colors, and they were inconsistent. Here I propose that HTML tags have a consistent color:

Before:

![screen shot 2015-02-19 at 1 02 05 pm](https://cloud.githubusercontent.com/assets/25882/6280289/874d1474-b8e5-11e4-8d76-fa1164d3ba5f.png)

After:

![screen shot 2015-02-19 at 1 02 17 pm](https://cloud.githubusercontent.com/assets/25882/6280290/8754e320-b8e5-11e4-9704-476931517f9b.png)

I have no idea what I'm doing, and if you even want this, but just thought I'd share it.