### PR TITLE
Add conceal colors

### DIFF
--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -372,6 +372,7 @@ hi! link Error ErrorMsg
 hi! link MoreMsg Special
 call s:X("Question","65C254","","","Green","")
 
+call s:X("Conceal","902020","","bold","DarkRed","")
 
 " Spell Checking
 

--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -376,10 +376,10 @@ call s:X("Conceal","902020","","bold","DarkRed","")
 
 " Spell Checking
 
-call s:X("SpellBad","","902020","underline","","DarkRed")
-call s:X("SpellCap","","0000df","underline","","Blue")
-call s:X("SpellRare","","540063","underline","","DarkMagenta")
-call s:X("SpellLocal","","2D7067","underline","","Green")
+call s:X("SpellBad","","902020","underline","DarkRed","")
+call s:X("SpellCap","","0000df","underline","Blue","")
+call s:X("SpellRare","","540063","underline","DarkMagenta","")
+call s:X("SpellLocal","","2D7067","underline","Green","")
 
 " Diff
 

--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -376,10 +376,10 @@ call s:X("Conceal","902020","","bold","DarkRed","")
 
 " Spell Checking
 
-call s:X("SpellBad","","902020","underline","DarkRed","")
-call s:X("SpellCap","","0000df","underline","Blue","")
-call s:X("SpellRare","","540063","underline","DarkMagenta","")
-call s:X("SpellLocal","","2D7067","underline","Green","")
+call s:X("SpellBad","902020","","underline","DarkRed","")
+call s:X("SpellCap","0000df","","underline","Blue","")
+call s:X("SpellRare","540063","","underline","DarkMagenta","")
+call s:X("SpellLocal","2D7067","","underline","Green","")
 
 " Diff
 


### PR DESCRIPTION
Some haskell plugins uses conceals to color create lambdas and such. These where not colored in the current version of jellybeans. I just used DarkRed as a tempalate and it works ok.