### PR TITLE
Add javascript template string.

### DIFF
--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -446,6 +446,9 @@ hi! link erlangNode Identifier
 
 hi! link javaScriptValue Constant
 hi! link javaScriptRegexpString rubyRegexp
+hi! link javaScriptTemplateVar StringDelim
+hi! link javaScriptTemplateDelim Identifier
+hi! link javaScriptTemplateString String
 
 " CoffeeScript
 


### PR DESCRIPTION
A possible fix for #42.  It's dependent on [jelera/vim-javascript-syntax](https://github.com/jelera/vim-javascript-syntax/blob/master/syntax/javascript.vim#L187) though.