### PR TITLE
Inverse jellybeans_use_term_background_color logic

### DIFF
--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -331,7 +331,7 @@ fun! s:X(group, fg, bg, attr, lcfg, lcbg)
     let l:fge = empty(a:fg)
     let l:bge = empty(a:bg)
 
-    if !g:jellybeans_use_term_background_color && a:bg == s:background_color
+    if g:jellybeans_use_term_background_color && a:bg == s:background_color
       let l:ctermbg = 'NONE'
     else
       let l:ctermbg = s:rgb(a:bg)


### PR DESCRIPTION
It seems `g:jellybeans_use_term_background_color` has inverted behaviour
since when it's enabled (`1`) - Jellybeans' background is used (black).
And vice versa, when it's disabled (`0`) - terminal's background is
used.

This commit fixes wrong behaviour and inverse logic of that flag.

Fixes #51