### PR TITLE
Enable high-color modes in more cases

### DIFF
--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -65,7 +65,7 @@ endif
 
 let colors_name = "jellybeans"
 
-if has("gui_running") || &t_Co >= 88
+if has("gui_running") || (exists('&tgc') && &termguicolors) || &t_Co >= 88
   let s:low_color = 0
 else
   let s:low_color = 1

--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -65,7 +65,7 @@ endif
 
 let colors_name = "jellybeans"
 
-if has("gui_running") || &t_Co == 88 || &t_Co == 256
+if has("gui_running") || &t_Co >= 88
   let s:low_color = 0
 else
   let s:low_color = 1


### PR DESCRIPTION
I'm attempting to migrate away from my custom fork of Vim now that true-color terminal support has been upstreamed.  I discovered that `jellybeans.vim` checks explicitly for 88- or 256-color terminals when disabling the low-color flag.  Instead, I think it should check for 88- or more-color terminals, which seems closer to the actual condition needed for gui-like colors.  (E.g., personally, I use `t_Co = 32767` (max value) in a custom termcap to indicate 24-bit color support, since there's no official standard.)

Additionally, I think it makes sense to use hi-color mode (low_color = 0) if the `termguicolors` option exists and is set.
