### PR TITLE
added xmlTagN (bad xmlTagName)

### DIFF
--- a/colors/jellybeans.vim
+++ b/colors/jellybeans.vim
@@ -582,6 +582,7 @@ hi! link htmlTagName htmlTag
 hi! link xmlTag Statement
 hi! link xmlEndTag xmlTag
 hi! link xmlTagName xmlTag
+hi! link xmlTagN xmlTag
 hi! link xmlEqual xmlTag
 hi! link xmlEntity Special
 hi! link xmlEntityPunct xmlEntity


### PR DESCRIPTION
I have an odd JSX problem where the opening tag is correctly highlighted as `xmlTagName` but the closing one is `xmlTagN` --- but I can not determine why this is the case...

It's certainly not a great solution, to just color code the errored syntax, but it does work for now and would probably help anyone else out who is having the same JSX highlighting problems... (there are several)

![ss](https://puu.sh/vRbAG/3797e4f5a1.png)